### PR TITLE
add upload_files to fix issue #28

### DIFF
--- a/deep_predictive_maintenance/train/entry.py
+++ b/deep_predictive_maintenance/train/entry.py
@@ -74,4 +74,5 @@ if __name__ == '__main__':
     model_path = os.path.join(output_dir, 'network.pth')
     
     torch.save(network, model_path)
+    run.upload_file(model_path, model_path)
     run.register_model(model_name = 'network.pth', model_path = model_path)


### PR DESCRIPTION
issue caused by child runs attempting to register model before artifact is saved to outputs folder.  Added upload_files step to push model into Run output for registration.
fixes https://github.com/Azure/AMLSamples/issues/28